### PR TITLE
bumped to v4 endpoints, removed feedback, and added /start return pos…

### DIFF
--- a/module/index.ts
+++ b/module/index.ts
@@ -16,11 +16,6 @@ export async function start(apiKey: string, modelKey: string, modelInputs: objec
   return callID
 }
 
-export async function feedback(apiKey: string, callID: string, feedback: object = {}): Promise<object>{
-  const jsonOut = await genericsUtils.feedback(apiKey, callID, feedback)
-  return jsonOut
-}
-
 export async function check(apiKey: string, callID: string): Promise<object>{
   const jsonOut = await genericsUtils.checkMain(apiKey, callID)
   return jsonOut

--- a/module/package.json
+++ b/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banana-dev/banana-dev",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A typescript-friendly node client to interact with Banana's machine learning inference APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Why
We've depricated parts of the backend in an attempt to simplify it of backward compatibility, therefore we're making fresh endpoints on a new major version to make sure that pre-serverless users of our backend have a stable 3.x.x release now that we're on 4.x.x

The API itself is not changing, so no need for users to rewrite their code. We're just deprecating old parts of the backend.

# Testing
Tested end-to-end with recently deployed v4 endpoints on backend, everything works as expected.