### PR TITLE
:memo: Fix node code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Get your API Key
 
 Run:
 ```javascript
-import banana = require("@banana-dev/banana-dev")
+const banana = require("@banana-dev/banana-dev")
 
 const apiKey = "demo" // "YOUR_API_KEY"
 const modelKey = "carrot" // "YOUR_MODEL_KEY"


### PR DESCRIPTION
- Change import for const so it executes without an error

# What is this?

Update node example in readme

# Why?

Currently it fails if you copy and paste it with the error
```
SyntaxError: Cannot use import statement outside a module
```

# How did you test it? 

CLI Node 18