### PR TITLE
BREAKING: remove model key

### DIFF
--- a/module/index.ts
+++ b/module/index.ts
@@ -11,15 +11,13 @@ export class ClientException extends Error {
 
 export class Client {
   private apiKey: string;
-  private modelKey: string;
   private url: string;
-  private verbose: boolean;
+  private verbosity: string;
 
-  constructor(apiKey: string, modelKey: string, url: string, verbose: boolean = true) {
+  constructor(apiKey: string, url: string, verbosity: string = "DEBUG") {
     this.apiKey = apiKey;
-    this.modelKey = modelKey;
     this.url = url;
-    this.verbose = verbose;
+    this.verbosity = verbosity;
   }
 
   public call = async (route: string, json: object = {}, headers: object = {}, retry = true, retryTimeoutMs = 300000) => {
@@ -28,7 +26,6 @@ export class Client {
     headers = {
       'Content-Type': 'application/json',
       'X-BANANA-API-KEY': this.apiKey,
-      'X-BANANA-MODEL-KEY': this.modelKey,
       'X-BANANA-REQUEST-ID': uuidv4(), // we use the same uuid to track all retries
       ...headers,
     }
@@ -46,7 +43,7 @@ export class Client {
       if (firstCall) {
         firstCall = false;
       } else {
-        if (this.verbose) {
+        if (this.verbosity === "DEBUG") {
           console.log('Retrying...');
         }
       }
@@ -55,7 +52,7 @@ export class Client {
 
       const res = await this.makeRequest(endpoint, json, headers);
 
-      if (this.verbose && res.statusCode !== 200) {
+      if (this.verbosity === "DEBUG" && res.statusCode !== 200) {
         console.log('Status code:', res.statusCode);
         console.log(res.body);
       }

--- a/module/package-lock.json
+++ b/module/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@banana-dev/banana-dev",
-  "version": "5.0.3",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@banana-dev/banana-dev",
-      "version": "5.0.3",
+      "version": "6.0.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.0",
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@types/node": "^17.0.13",
-        "@types/uuid": "^9.0.3"
+        "@types/uuid": "^9.0.4"
       }
     },
     "node_modules/@types/node": {
@@ -28,9 +28,9 @@
       "dev": true
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.3.tgz",
-      "integrity": "sha512-taHQQH/3ZyI3zP8M/puluDEIEvtQHVYcC6y3N8ijFtAd28+Ey/G4sg1u2gB01S8MwybLOKAp9/yCMu/uR5l3Ug==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==",
       "dev": true
     },
     "node_modules/axios": {
@@ -145,9 +145,9 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.3.tgz",
-      "integrity": "sha512-taHQQH/3ZyI3zP8M/puluDEIEvtQHVYcC6y3N8ijFtAd28+Ey/G4sg1u2gB01S8MwybLOKAp9/yCMu/uR5l3Ug==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.4.tgz",
+      "integrity": "sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==",
       "dev": true
     },
     "axios": {

--- a/module/package.json
+++ b/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banana-dev/banana-dev",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "A typescript-friendly node client to interact with Banana's machine learning inference APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.13",
-    "@types/uuid": "^9.0.3"
+    "@types/uuid": "^9.0.4"
   }
 }


### PR DESCRIPTION
# What is this?
We deprecate the modelKey argument from client creation

# Why?
It was redundant in terms of auth with the URL value, so we're removing. Plus, we're renaming "model" to "project" so model_key is confusing 

# How did you test it works without regressions?
Did a call against the updated production without a model key and it ran as expected.
