### PR TITLE
Warmup endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ npx tsc --init
 cd ../module
 npm install
 npm link
+npx tsc
 cd ../tests
-npm link @banana-dev/banana-dev
+npm install --save ../module
 npx tsc -w
 ```
 

--- a/module/index.ts
+++ b/module/index.ts
@@ -20,6 +20,10 @@ export class Client {
     this.verbosity = verbosity;
   }
 
+  public warmup = async () => {
+    return this.call('/_k/warmup', {}, {}, false);
+  }
+
   public call = async (route: string, json: object = {}, headers: object = {}, retry = true, retryTimeoutMs = 300000) => {
     const endpoint = `${this.url.replace(/\/$/, '')}/${route.replace(/^\//, '')}`;
 

--- a/module/index.ts
+++ b/module/index.ts
@@ -142,7 +142,7 @@ export class Client {
       }, (res: http.IncomingMessage) => {
         let body = '';
 
-        res.on('data', (chunk: any) => {
+        res.on('data', (chunk: string) => {
           body += chunk;
         });
 

--- a/module/index.ts
+++ b/module/index.ts
@@ -135,10 +135,10 @@ export class Client {
       const req = protocol.request(url, {
         method: 'POST',
         headers: {...headers,},
-      }, (res) => {
+      }, (res: http.IncomingMessage) => {
         let body = '';
 
-        res.on('data', (chunk) => {
+        res.on('data', (chunk: any) => {
           body += chunk;
         });
 
@@ -147,7 +147,7 @@ export class Client {
         });
       });
 
-      req.on('error', (error) => {
+      req.on('error', (error: Error) => {
         reject(error);
       });
 

--- a/module/package-lock.json
+++ b/module/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@banana-dev/banana-dev",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@banana-dev/banana-dev",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.0",

--- a/module/package.json
+++ b/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banana-dev/banana-dev",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "A typescript-friendly node client to interact with Banana's machine learning inference APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# What is this?

Allows calling the Potassium "warmup" endpoint from the SDK.

Fixes BAN-392

# Why?

It's now natively in Potassium, so let's make it easy to use in the SDK rather than having to manually call the model's internal API endpoint.

# How did you test it works without  regressions?

<img width="1104" alt="image" src="https://github.com/bananaml/banana-node-sdk/assets/6206742/0a0955e7-b537-4972-8791-2becae5b7149">

<img width="499" alt="image" src="https://github.com/bananaml/banana-node-sdk/assets/6206742/9ee9f752-217b-4675-ae10-0ebe2f83ef0d">

<img width="1014" alt="image" src="https://github.com/bananaml/banana-node-sdk/assets/6206742/f9b08d5b-fb5b-403a-896b-dad9cd36f120">

<img width="500" alt="image" src="https://github.com/bananaml/banana-node-sdk/assets/6206742/92e6bb1c-54ef-4b00-ad95-62d871f6edd1">
