### PR TITLE
API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ npx tsc -w
 This monitors all the .ts files in the module dir. If any changes, it will recompile the .ts files into .js and store in /dist
 
 # Testing
-## we use the npm link command so our tests import @banana-dev/banana-dev but use the local module repo
+
+We use the npm link command so our tests import @banana-dev/banana-dev but use the local module repo
 ```bash
 mkdir tests
 cd tests
@@ -27,6 +28,11 @@ npx tsc
 cd ../tests
 npm install --save ../module
 npx tsc -w
+```
+
+Run the `index.ts` script in your tests using
+```bash
+npx node-ts index.ts
 ```
 
 If you're seeing any import errors make sure you've ran npm install in the module directory

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # Banana Node/TypeScript SDK
 
-# Usage
+## Usage
 
 For usage docs please refer to our [Banana SDK documentation](https://docs.banana.dev/banana-docs/core-concepts/sdks/node.js)
 
-# ----------------------
-# Developing on the SDK:
+## Developing on the SDK
 
-# Building
+### Building
 Run the typescript compiler in watch mode. If it fails using the npx command just run without npx
 cd module
 npx tsc -w
 
 This monitors all the .ts files in the module dir. If any changes, it will recompile the .ts files into .js and store in /dist
 
-# Testing
+### Testing
 
 We use the npm link command so our tests import @banana-dev/banana-dev but use the local module repo
 ```bash

--- a/module/index.ts
+++ b/module/index.ts
@@ -165,32 +165,28 @@ export class Client {
   };
 }
 
-const API_BASE_URL = "https://api.banana.dev/v1";
-
 export class API {
+  private baseUrl: string = "https://api.banana.dev/v1";
   private apiKey: string;
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
   }
 
-  public projects = () => {
-    return new ProjectsAPI(this.apiKey);
-  }
-}
-
-class BaseAPI {
-  private apiKey: string;
-
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
+  public listProjects = async () => {
+    return await this.makeRequest('GET', `${this.baseUrl}/projects`);
   }
 
-  protected makeRequest = async (method: string, url: string, data: object = {}, headers: object = {}) => {
-    const res = await this.makeAPIRequest(method, url, data, {
-      'X-BANANA-API-KEY': this.apiKey,
-      ...headers,
-    });
+  public getProject = async (projectId: string) => {
+    return await this.makeRequest('GET', `${this.baseUrl}/projects/${projectId}`);
+  }
+
+  public updateProject = async (projectId: string, data: object) => {
+    return await this.makeRequest('PUT', `${this.baseUrl}/projects/${projectId}`, data);
+  }
+
+  private makeRequest = async (method: string, url: string, data: object = {}, headers: object = {}) => {
+    const res = await this.makeAPIRequest(method, url, data,  headers)
     
     const meta = { headers: res.headers };
     
@@ -204,7 +200,7 @@ class BaseAPI {
     return {json, meta};
   }
 
-  protected makeAPIRequest = (method: string, url: string, data: object = {}, headers: object = {}) => {
+  private makeAPIRequest = (method: string, url: string, data: object = {}, headers: object = {}) => {
     return new Promise<{ statusCode: number, headers: http.IncomingHttpHeaders, body: string }>((resolve, reject) => {
       const protocol = url.startsWith('https') ? https : http;
 
@@ -217,7 +213,9 @@ class BaseAPI {
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
-          ...headers,},
+          'X-BANANA-API-KEY': this.apiKey,
+          ...headers,
+        },
       }, (res: http.IncomingMessage) => {
         let body = '';
 
@@ -242,25 +240,4 @@ class BaseAPI {
       req.end();
     });
   };
-}
-
-export class ProjectsAPI extends BaseAPI {
-  private baseUrl: string;
-  
-  constructor(apiKey: string) {
-    super(apiKey);
-    this.baseUrl = `${API_BASE_URL}/projects`;
-  }
-
-  public list = async () => {
-    return await this.makeAPIRequest('GET', `${this.baseUrl}`);
-  }
-
-  public get = async (projectId: string) => {
-    return await this.makeAPIRequest('GET', `${this.baseUrl}/${projectId}`);
-  }
-
-  public update = async (projectId: string, data: object) => {
-    return await this.makeAPIRequest('PUT', `${this.baseUrl}/${projectId}`, data);
-  }
 }

--- a/module/index.ts
+++ b/module/index.ts
@@ -180,21 +180,21 @@ export class API {
     this.apiKey = apiKey.trim();
   }
 
-  public listProjects = async (): Promise<{json: Projects}> => {
+  public listProjects = async (): Promise<{json: Projects, status: number}> => {
     return await this.makeRequest('GET', `${this.baseUrl}/projects`);
   }
 
-  public getProject = async (projectId: string): Promise<{json: Project}> => {
+  public getProject = async (projectId: string): Promise<{json: Project, status: number}> => {
     return await this.makeRequest('GET', `${this.baseUrl}/projects/${projectId}`);
   }
 
-  public updateProject = async (projectId: string, data: object): Promise<{json: Project}> => {
+  public updateProject = async (projectId: string, data: object): Promise<{json: Project, status: number}> => {
     return await this.makeRequest('PUT', `${this.baseUrl}/projects/${projectId}`, data);
   }
 
-  private makeRequest = async (method: string, url: string, data: object = {}, headers: object = {}): Promise<{json: any}> => {
+  private makeRequest = async (method: string, url: string, data: object = {}, headers: object = {}): Promise<{json: any, status: number}> => {
     const res = await this.makeAPIRequest(method, url, data,  headers)
-    
+
     let json = {}
     try {
       json = JSON.parse(res.body);
@@ -202,7 +202,7 @@ export class API {
       //
     }
     
-    return {json};
+    return {json, status: res.statusCode};
   }
 
   private makeAPIRequest = (method: string, url: string, data: object = {}, headers: object = {}) => {

--- a/module/index.ts
+++ b/module/index.ts
@@ -194,15 +194,8 @@ export class API {
 
   private makeRequest = async (method: string, url: string, data: object = {}, headers: object = {}): Promise<{json: any, status: number}> => {
     const res = await this.makeAPIRequest(method, url, data,  headers)
-
-    let json = {}
-    try {
-      json = JSON.parse(res.body);
-    } catch {
-      //
-    }
     
-    return {json, status: res.statusCode};
+    return {json: JSON.parse(res.body), status: res.statusCode};
   }
 
   private makeAPIRequest = (method: string, url: string, data: object = {}, headers: object = {}) => {

--- a/module/index.ts
+++ b/module/index.ts
@@ -169,22 +169,20 @@ const API_BASE_URL = "https://api.banana.dev/v1";
 
 export class API {
   private apiKey: string;
-  private verbosity: string;
 
-  constructor(apiKey: string, url: string, verbosity: string = "DEBUG") {
+  constructor(apiKey: string) {
     this.apiKey = apiKey;
-    this.verbosity = verbosity;
   }
 
   public projects = () => {
-    return new ProjectsAPI(this.apiKey, this.verbosity);
+    return new ProjectsAPI(this.apiKey);
   }
 }
 
 class BaseAPI {
   private apiKey: string;
 
-  constructor(apiKey: string, verbosity: string = "DEBUG") {
+  constructor(apiKey: string) {
     this.apiKey = apiKey;
   }
 
@@ -249,7 +247,7 @@ class BaseAPI {
 export class ProjectsAPI extends BaseAPI {
   private baseUrl: string;
   
-  constructor(apiKey: string, verbosity: string = "DEBUG") {
+  constructor(apiKey: string) {
     super(apiKey);
     this.baseUrl = `${API_BASE_URL}/projects`;
   }

--- a/module/index.ts
+++ b/module/index.ts
@@ -165,6 +165,13 @@ export class Client {
   };
 }
 
+type Project = {
+  [key: string]: any
+};
+type Projects = {
+  results: Project[]
+}
+
 export class API {
   private baseUrl: string = "https://api.banana.dev/v1";
   private apiKey: string;
@@ -173,22 +180,20 @@ export class API {
     this.apiKey = apiKey.trim();
   }
 
-  public listProjects = async () => {
+  public listProjects = async (): Promise<{json: Projects}> => {
     return await this.makeRequest('GET', `${this.baseUrl}/projects`);
   }
 
-  public getProject = async (projectId: string) => {
+  public getProject = async (projectId: string): Promise<{json: Project}> => {
     return await this.makeRequest('GET', `${this.baseUrl}/projects/${projectId}`);
   }
 
-  public updateProject = async (projectId: string, data: object) => {
+  public updateProject = async (projectId: string, data: object): Promise<{json: Project}> => {
     return await this.makeRequest('PUT', `${this.baseUrl}/projects/${projectId}`, data);
   }
 
-  private makeRequest = async (method: string, url: string, data: object = {}, headers: object = {}) => {
+  private makeRequest = async (method: string, url: string, data: object = {}, headers: object = {}): Promise<{json: any}> => {
     const res = await this.makeAPIRequest(method, url, data,  headers)
-    
-    const meta = { headers: res.headers };
     
     let json = {}
     try {
@@ -197,7 +202,7 @@ export class API {
       //
     }
     
-    return {json, meta};
+    return {json};
   }
 
   private makeAPIRequest = (method: string, url: string, data: object = {}, headers: object = {}) => {

--- a/module/index.ts
+++ b/module/index.ts
@@ -170,7 +170,7 @@ export class API {
   private apiKey: string;
 
   constructor(apiKey: string) {
-    this.apiKey = apiKey;
+    this.apiKey = apiKey.trim();
   }
 
   public listProjects = async () => {

--- a/module/package.json
+++ b/module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@banana-dev/banana-dev",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A typescript-friendly node client to interact with Banana's machine learning inference APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# What is this?

Provides access to the [Banana API](https://docs.api.banana.dev/) natively in the SDK.

Closes BAN-401

# Why?

A few less steps required for devs to interact with Banana ecosystem.

# Testing

<img width="1367" alt="image" src="https://github.com/bananaml/banana-node-sdk/assets/6206742/ccbc02cc-2c4c-4ec6-bb6d-9aa203353dbb">

